### PR TITLE
remove slash from base-16-nord name

### DIFF
--- a/base16-nord/src/index.ts
+++ b/base16-nord/src/index.ts
@@ -15,7 +15,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
     const style = '@arbennett/base16-nord/index.css';
 
     manager.register({
-      name: '/base16-nord',
+      name: 'base16-nord',
       isLight: false,
       load: () => manager.loadCSS(style),
       unload: () => Promise.resolve(undefined)


### PR DESCRIPTION
Removes this slash that is inconsistent with the other themes:
![image](https://user-images.githubusercontent.com/10111092/107994127-fbd30980-6fa9-11eb-90b6-eedd7915da6b.png)
